### PR TITLE
fix: use raw strings for fastener regexes

### DIFF
--- a/addons/cad_fasteners/cad_fasteners.py
+++ b/addons/cad_fasteners/cad_fasteners.py
@@ -269,10 +269,10 @@ def on_object_cad_fast_is_fastener_prop_updated(self, context):
     ob = context.active_object
 
     if ob != None and ob.cad_fast.is_fastener:
-        if re.match('M[^X]*X[^ \s]*.*', ob.name):
-            size_designator = re.sub('M([^X]*)X.*', r'M\1', ob.name)
-            length = re.sub('M[^X]*X([^ \s]*).*', r'\1', ob.name)
-        elif re.match('M[0-9]+ Nut.*', ob.name):
+        if re.match(r'M[^X]*X[^ \s]*.*', ob.name):
+            size_designator = re.sub(r'M([^X]*)X.*', r'M\1', ob.name)
+            length = re.sub(r'M[^X]*X([^ \s]*).*', r'\1', ob.name)
+        elif re.match(r'M[0-9]+ Nut.*', ob.name):
             cad_fast_prop_set(ob, 'standard', 'DIN_934-1')
             size_designator = re.sub('M([0-9]+) Nut.*', r'M\1', ob.name)
             length = '10'


### PR DESCRIPTION
## Summary
- avoid invalid escape sequence warnings by converting regex patterns in CAD Fasteners to raw strings

## Testing
- `python -m compileall addons`


------
https://chatgpt.com/codex/tasks/task_e_68ae8adfc00483329b8b84a864a40c16